### PR TITLE
handle paid partial options

### DIFF
--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
@@ -128,10 +128,14 @@ public class ShopifyHostedService : EventHostedServiceBase
             {
                 try
                 {
+                    decimal amount = invoice.Status == InvoiceStatus.Settled ? invoice.Price : invoice.PaidAmount.Net;
+                    var numberFormat = _currencyNameTable.GetNumberFormatInfo(invoice.Currency);
+                    int decimalPlaces = numberFormat?.CurrencyDecimalDigits ?? 2;
+
                     await client.CaptureOrder(new()
                     {
                         Currency = invoice.Currency,
-                        Amount = Math.Round(invoice.PaidAmount.Net, _currencyNameTable.GetNumberFormatInfo(invoice.Currency).CurrencyDecimalDigits),
+                        Amount = Math.Round(amount, decimalPlaces),
                         Id = order.Id,
                         ParentTransactionId = saleTx.Id
                     });

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
@@ -103,7 +103,7 @@ public class ShopifyHostedService : EventHostedServiceBase
                 .Where(h => h is { Kind: "REFUND", Status: "SUCCESS" }).ToArray();
 
         bool canRefund = captures.Length > 0 && captures.Length > refunds.Length;
-        if (invoice.Status is InvoiceStatus.Settled || invoice.ExceptionStatus == InvoiceExceptionStatus.PaidPartial)
+        if (invoice.Status is InvoiceStatus.Settled || (invoice.Status == InvoiceStatus.Expired && invoice.ExceptionStatus == InvoiceExceptionStatus.PaidPartial))
         {
             if (canRefund)
             {

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
@@ -68,7 +68,7 @@ public class ShopifyHostedService : EventHostedServiceBase
         }
     }
 
-    async Task<InvoiceLogs> Process(long shopifyOrderId, InvoiceEntity invoice, bool paidPartial = false)
+    async Task<InvoiceLogs> Process(long shopifyOrderId, InvoiceEntity invoice)
     {
 		var logs = new InvoiceLogs();
 		var client = await shopifyClientFactory.CreateAPIClient(invoice.StoreId);

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
@@ -128,13 +128,13 @@ public class ShopifyHostedService : EventHostedServiceBase
             {
                 try
                 {
-                    decimal amount = invoice.Status == InvoiceStatus.Settled ? invoice.Price : invoice.PaidAmount.Net;
-                    int decimalPlaces = _currencyNameTable.GetNumberFormatInfo(invoice.Currency)?.CurrencyDecimalDigits ?? 2;
+                    decimal amount = invoice.Status == InvoiceStatus.Settled ? invoice.Price 
+                        : Math.Round(invoice.PaidAmount.Net, _currencyNameTable.GetNumberFormatInfo(invoice.Currency)?.CurrencyDecimalDigits ?? 2);
 
                     await client.CaptureOrder(new()
                     {
                         Currency = invoice.Currency,
-                        Amount = Math.Round(amount, decimalPlaces),
+                        Amount = amount,
                         Id = order.Id,
                         ParentTransactionId = saleTx.Id
                     });

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
@@ -129,8 +129,7 @@ public class ShopifyHostedService : EventHostedServiceBase
                 try
                 {
                     decimal amount = invoice.Status == InvoiceStatus.Settled ? invoice.Price : invoice.PaidAmount.Net;
-                    var numberFormat = _currencyNameTable.GetNumberFormatInfo(invoice.Currency);
-                    int decimalPlaces = numberFormat?.CurrencyDecimalDigits ?? 2;
+                    int decimalPlaces = _currencyNameTable.GetNumberFormatInfo(invoice.Currency)?.CurrencyDecimalDigits ?? 2;
 
                     await client.CaptureOrder(new()
                     {

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
@@ -142,10 +142,6 @@ public class ShopifyHostedService : EventHostedServiceBase
                 }
             }
         }
-        if (invoice.Status == InvoiceStatus.Expired && invoice.ExceptionStatus == InvoiceExceptionStatus.PaidPartial)
-        {
-            // Mark order as paid partial
-        }
         else if(order.CancelledAt is null)
         {
             try


### PR DESCRIPTION
At the moment, once an amount is less than the order amount, shopify marks it as partially paid, I had to manually change the invoice amount to achieve this (see images below). 

![image](https://github.com/user-attachments/assets/86dff365-1eb1-4190-9ce6-615d2abb5c89)

![image](https://github.com/user-attachments/assets/4fb2239d-e50d-41b4-a46a-c1f866ba4d25)

![image](https://github.com/user-attachments/assets/5e9a8cfa-8a0d-49fc-9567-947ab8daa853)

This changes also include scenarios where BTCPay invoices status is marked as paid partial and the invoice is expired, in that case captureOrder is also called. If the amount is less than the order amount, then Shopify marks it as partial payment, else if the amount is the same, it marks it as settled

Once marked as partial payment in Shopify, the merchant has three options with regards to that  particular order (mark as paid, refund, or send an invoice to the customer to complete the balance)...