### PR TITLE
Auto creates invoice if the payment option is BTCPay Server

### DIFF
--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Clients/ShopifyApiClient.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Clients/ShopifyApiClient.cs
@@ -5,19 +5,13 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
-using Google.Apis.Auth.OAuth2;
 using System.IdentityModel.Tokens.Jwt;
 using Microsoft.IdentityModel.Tokens;
-using System.Net;
 using System.Security.Cryptography;
 using Newtonsoft.Json.Serialization;
-using System.Globalization;
 using BTCPayServer.Plugins.ShopifyPlugin.JsonConverters;
 using Newtonsoft.Json.Converters;
-using System.Text.RegularExpressions;
-using System.Security;
 using Microsoft.AspNetCore.WebUtilities;
 using JArray = Newtonsoft.Json.Linq.JArray;
 
@@ -235,7 +229,7 @@ namespace BTCPayServer.Plugins.ShopifyPlugin.Clients
 		}
 
         const string OrderData =
-			"""
+            """
             fragment order on Order {
                 id
                 name
@@ -254,8 +248,9 @@ namespace BTCPayServer.Plugins.ShopifyPlugin.Clients
                 transactions @include(if: $includeTxs) {
                     ...orderTransaction
                 }
+                ...orderPaymentProcess
             }
-            """ + "\n" + TransactionData;
+            """ + "\n" + TransactionData + "\n" + PaymentProcessData;
 
         private const string TransactionData =
 	        """
@@ -278,7 +273,14 @@ namespace BTCPayServer.Plugins.ShopifyPlugin.Clients
 	            }
 	        }
 	        """;
-		public async Task<ShopifyOrder> GetOrder(long orderId, bool withTransactions = false)
+
+        private const string PaymentProcessData =
+            """
+            fragment orderPaymentProcess on Order {
+                paymentGatewayNames
+            }
+            """;
+        public async Task<ShopifyOrder> GetOrder(long orderId, bool withTransactions = false)
 		{
 			// https://shopify.dev/docs/api/admin-graphql/2024-10/queries/order
 			var req = """

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Clients/ShopifyOrder.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Clients/ShopifyOrder.cs
@@ -55,6 +55,7 @@ public class ShopifyOrder
 	public DateTimeOffset? CancelledAt { get; set; }
 	public ShopifyMoneyBag TotalOutstandingSet { get; set; }
 	public OrderTransaction[] Transactions { get; set; }
+    public string[] PaymentGatewayNames { get; set; }
 }
 public class ShopifyMoneyBag
 {

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Clients/UpdateMetafields.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Clients/UpdateMetafields.cs
@@ -1,0 +1,14 @@
+﻿namespace BTCPayServer.Plugins.ShopifyPlugin.Clients;
+
+public class UpdateMetafields
+{
+	public class Metafield
+	{
+		public string Namespace { get; set; }
+		public string Key { get; set; }
+		public string Type { get; set; }
+		public string Value { get; set; }
+	}
+	public ShopifyId Id { get; set; }
+	public Metafield[] Metafields { get; set; }
+}

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Controllers/UIShopifyV2Controller.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Controllers/UIShopifyV2Controller.cs
@@ -238,8 +238,8 @@ public class UIShopifyV2Controller : Controller
 
     static AsyncDuplicateLock OrderLocks = new AsyncDuplicateLock();
     [AllowAnonymous]
-    [EnableCors(CorsPolicies.All)]
-    [HttpGet("~/stores/{storeId}/plugins/shopify-v2/checkout")]
+	[EnableCors(CorsPolicies.All)]
+	[HttpGet("~/stores/{storeId}/plugins/shopify-v2/checkout")]
     public async Task<IActionResult> Checkout(string storeId, string? checkout_token, CancellationToken cancellationToken, bool redirect = true)
     {
         if (checkout_token is null)
@@ -306,7 +306,19 @@ public class UIShopifyV2Controller : Controller
 
         if (invoice == null) return BadRequest("An error occured while creating invoice");
 
-        await client.AddBtcPayCheckoutUrlToOrderMetaData(orderId, Url.Action(nameof(Checkout), "UIShopifyV2", new { storeId, checkout_token }, Request.Scheme));
+        await client.UpdateOrderMetafields(new()
+		{
+			Id = ShopifyId.Order(orderId),
+			Metafields = [
+				new()
+				{
+					Namespace = "custom",
+					Key = "btcpay_checkout_url",
+					Type = "single_line_text_field",
+					Value = Url.Action(nameof(Checkout), "UIShopifyV2", new { storeId, checkout_token }, Request.Scheme)
+				}
+			]
+		});
         return redirect ? RedirectToInvoiceCheckout(invoice.Id) : Ok();
     }
 

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Controllers/UIShopifyV2Controller.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Controllers/UIShopifyV2Controller.cs
@@ -240,7 +240,7 @@ public class UIShopifyV2Controller : Controller
     [AllowAnonymous]
     [EnableCors(CorsPolicies.All)]
     [HttpGet("~/stores/{storeId}/plugins/shopify-v2/checkout")]
-    public async Task<IActionResult> Checkout(string storeId, string? checkout_token, bool redirect = true, CancellationToken cancellationToken)
+    public async Task<IActionResult> Checkout(string storeId, string? checkout_token, CancellationToken cancellationToken, bool redirect = true)
     {
         if (checkout_token is null)
             return BadRequest("Invalid checkout token");

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Controllers/UIShopifyV2Controller.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Controllers/UIShopifyV2Controller.cs
@@ -28,8 +28,6 @@ using BTCPayServer.Plugins.ShopifyPlugin.Clients;
 using BTCPayServer.Plugins.ShopifyPlugin.ViewModels;
 using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.Cors;
-using BTCPayServer.Plugins.Shopify;
-using ShopifyApiClient = BTCPayServer.Plugins.ShopifyPlugin.Clients.ShopifyApiClient;
 
 namespace BTCPayServer.Plugins.ShopifyPlugin;
 
@@ -343,7 +341,7 @@ public class UIShopifyV2Controller : Controller
         if (order is null || store is null)
             return (BadRequest("Invalid checkout token"), null);
 
-        var containsKeyword = order.PaymentGatewayNames.Any(pgName => ShopifyService.IsBTCPayServerGateway(pgName));
+        var containsKeyword = order.PaymentGatewayNames.Any(pgName => ShopifyHostedService.IsBTCPayServerGateway(pgName));
         if (!containsKeyword)
             return (BadRequest("Order wasn't fulfiled with BTCPay Server payment option"), null);
 

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Controllers/UIShopifyV2Controller.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Controllers/UIShopifyV2Controller.cs
@@ -300,7 +300,11 @@ public class UIShopifyV2Controller : Controller
                     }
                 }, store,
                 Request.GetAbsoluteRoot(), [searchTerm], cancellationToken);
-        return string.IsNullOrEmpty(invoice?.Id) ? BadRequest("An error occured while creating invoice") : Ok();
+
+		if (invoice == null) return BadRequest("An error occured while creating invoice");
+
+		await client.AddBtcPayCheckoutUrlToOrderMetaData(orderId, Url.Action("Checkout", "UIShopifyV2", new { storeId, checkout_token }, Request.Scheme));
+        return  Ok();
     }
 
 

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Controllers/UIShopifyV2Controller.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Controllers/UIShopifyV2Controller.cs
@@ -240,7 +240,7 @@ public class UIShopifyV2Controller : Controller
     [AllowAnonymous]
     [EnableCors(CorsPolicies.All)]
     [HttpGet("~/stores/{storeId}/plugins/shopify-v2/checkout")]
-    public async Task<IActionResult> Checkout(string storeId, string? checkout_token, bool redirect, CancellationToken cancellationToken)
+    public async Task<IActionResult> Checkout(string storeId, string? checkout_token, bool redirect = true, CancellationToken cancellationToken)
     {
         if (checkout_token is null)
             return BadRequest("Invalid checkout token");

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Plugin.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Plugin.cs
@@ -17,14 +17,5 @@ public class Plugin : BaseBTCPayServerPlugin
         services.AddUIExtension("header-nav", "ShopifyPluginHeaderNav");
 		services.AddSingleton<ShopifyClientFactory>();
         services.AddHostedService<ShopifyHostedService>();
-        services.AddCors(options =>
-        {
-            options.AddPolicy("AllowAllOrigins", builder =>
-            {
-                builder.AllowAnyOrigin()
-                       .AllowAnyMethod()
-                       .AllowAnyHeader();
-            });
-        });
     }
 }

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Plugin.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Plugin.cs
@@ -1,10 +1,7 @@
 using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Abstractions.Models;
-using BTCPayServer.Abstractions.Services;
 using BTCPayServer.Plugins.ShopifyPlugin.Services;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
-using System;
 
 namespace BTCPayServer.Plugins.ShopifyPlugin;
 
@@ -20,5 +17,14 @@ public class Plugin : BaseBTCPayServerPlugin
         services.AddUIExtension("header-nav", "ShopifyPluginHeaderNav");
 		services.AddSingleton<ShopifyClientFactory>();
         services.AddHostedService<ShopifyHostedService>();
+        services.AddCors(options =>
+        {
+            options.AddPolicy("AllowAllOrigins", builder =>
+            {
+                builder.AllowAnyOrigin()
+                       .AllowAnyMethod()
+                       .AllowAnyHeader();
+            });
+        });
     }
 }

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
@@ -5,10 +5,8 @@ using BTCPayServer.HostedServices;
 using BTCPayServer.Logging;
 using BTCPayServer.Plugins.ShopifyPlugin.Clients;
 using BTCPayServer.Services.Invoices;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -68,6 +66,13 @@ public class ShopifyHostedService : EventHostedServiceBase
         }
     }
 
+    private static string[] _keywords = new[] { "bitcoin", "btc", "btcpayserver", "btcpay server" };
+
+    public static bool IsBTCPayServerGateway(string gateway)
+    {
+        return _keywords.Any(keyword => gateway.Contains(keyword, StringComparison.OrdinalIgnoreCase));
+    }
+
     async Task<InvoiceLogs> Process(long shopifyOrderId, InvoiceEntity invoice)
     {
 		var logs = new InvoiceLogs();
@@ -76,7 +81,7 @@ public class ShopifyHostedService : EventHostedServiceBase
 			return logs;
 		if (await client.GetOrder(shopifyOrderId, true) is not { } order)
 			return logs;
-        
+
         var saleTx = order.Transactions.FirstOrDefault(h => h is { Kind: "SALE", Status: "PENDING" });
         if (saleTx is null)
             return logs;

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
@@ -5,11 +5,13 @@ using BTCPayServer.HostedServices;
 using BTCPayServer.Logging;
 using BTCPayServer.Plugins.ShopifyPlugin.Clients;
 using BTCPayServer.Services.Invoices;
+<<<<<<< HEAD
 using BTCPayServer.Services.Rates;
 using Microsoft.EntityFrameworkCore;
+=======
+>>>>>>> 54f9aa0 (refactor)
 using Microsoft.Extensions.Logging;
 using System;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -72,6 +74,13 @@ public class ShopifyHostedService : EventHostedServiceBase
         }
     }
 
+    private static string[] _keywords = new[] { "bitcoin", "btc", "btcpayserver", "btcpay server" };
+
+    public static bool IsBTCPayServerGateway(string gateway)
+    {
+        return _keywords.Any(keyword => gateway.Contains(keyword, StringComparison.OrdinalIgnoreCase));
+    }
+
     async Task<InvoiceLogs> Process(long shopifyOrderId, InvoiceEntity invoice)
     {
 		var logs = new InvoiceLogs();
@@ -80,7 +89,7 @@ public class ShopifyHostedService : EventHostedServiceBase
 			return logs;
 		if (await client.GetOrder(shopifyOrderId, true) is not { } order)
 			return logs;
-        
+
         var saleTx = order.Transactions.FirstOrDefault(h => h is { Kind: "SALE", Status: "PENDING" });
         if (saleTx is null)
             return logs;

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
@@ -5,11 +5,7 @@ using BTCPayServer.HostedServices;
 using BTCPayServer.Logging;
 using BTCPayServer.Plugins.ShopifyPlugin.Clients;
 using BTCPayServer.Services.Invoices;
-<<<<<<< HEAD
 using BTCPayServer.Services.Rates;
-using Microsoft.EntityFrameworkCore;
-=======
->>>>>>> 54f9aa0 (refactor)
 using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Views/UIShopify/Settings.cshtml
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Views/UIShopify/Settings.cshtml
@@ -147,6 +147,7 @@
                             <ul>
                                 <li><a href="https://docs.btcpayserver.org/ShopifyV2/#customize-the-thank-you-page" rel="noreferrer noopener" target="_blank">Customize the checkout's "Thank You" page</a> on your store's <a href="https://admin.shopify.com/store/@(Model.ShopName)/settings/checkout" rel="noreferrer noopener" target="_blank">checkout settings page</a>.</li>
                                 <li><a href="https://docs.btcpayserver.org/ShopifyV2/#set-up-a-custom-payment-method-in-shopify" rel="noreferrer noopener" target="_blank">Add BTCPay Server as a manual payment method</a> on your store's <a href="https://admin.shopify.com/store/@(Model.ShopName)/settings/payments" rel="noreferrer noopener" target="_blank">payment settings page</a>.</li>
+                                <li>Grant network access to your application. Go to your app on your partner's dashboard > API Access > scroll down to 'Allow network access in checkout and account UI extensions' and grant network access.</li>
                             </ul>
                         }
                         else

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Views/UIShopify/ShopifyAdmin.cshtml
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Views/UIShopify/ShopifyAdmin.cshtml
@@ -16,8 +16,9 @@
     {
         <p class="lead text-secondary mt-3">Your BTCPay Server-Shopify installation was successful!</p>
         <p class="mt-3">
-            <span>To start accepting payments, make sure to complete the two following steps:</span>
+            <span>To start accepting payments, make sure to complete the three following steps:</span>
             <ul class="list-unstyled">
+                <li>Grant network access to your application. Go to your app on your partner's dashboard > API Access > scroll down to 'Allow network access in checkout and account UI extensions' and grant network access.</li>
                 <li><a href="https://docs.btcpayserver.org/ShopifyV2/#customize-the-thank-you-page" rel="noreferrer noopener" target="_blank">Customize the checkout's "Thank You" page</a> on <a href="https://admin.shopify.com/store/@(Model.ShopName)/settings/checkout" rel="noreferrer noopener" target="_blank">this page</a>.</li>
                 <li><a href="https://docs.btcpayserver.org/ShopifyV2/#set-up-a-custom-payment-method-in-shopify" rel="noreferrer noopener" target="_blank">Add BTCPay Server as a Manual payment method</a> on <a href="https://admin.shopify.com/store/@(Model.ShopName)/settings/payments" rel="noreferrer noopener" target="_blank">this page</a>.</li>
             </ul>


### PR DESCRIPTION
- Added an extra endpoint to the plugin to create invoice. 
- Network access is now true on the app
- When the thank you page loads, the create invoice endpoint is triggered. During this process there is a spinner rolling in thank you page
- It checks if the payment options selected has btcpay labels in it, then goes ahead to create invoice
- With this the invoice gets created when thank you page is loaded. When the user clicks the Complete payment button, the created invoice is then displayed

- Also, when invoice is create, the checkout url is stored to shopify order meta data, should the customer not click the complete payment button and close the tab, the checkout url can be retrieved via the metadata interface or api (https://shopify-store.myshopify.com/admin/api/{Version_Date}/orders/{OrderId}/metafields.json)

Shopify app PR: https://github.com/btcpayserver/shopify-app/pull/8
