### PR TITLE
Better handling of BTCPay invoice state transitions

### DIFF
--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
@@ -79,7 +79,7 @@ public class ShopifyHostedService : EventHostedServiceBase
     }
 
     async Task<InvoiceLogs> Process(long shopifyOrderId, InvoiceEntity invoice)
-    {
+	{
 		var logs = new InvoiceLogs();
 		var client = await shopifyClientFactory.CreateAPIClient(invoice.StoreId);
 		if (client is null)
@@ -87,95 +87,87 @@ public class ShopifyHostedService : EventHostedServiceBase
 		if (await client.GetOrder(shopifyOrderId, true) is not { } order)
 			return logs;
 
-        var saleTx = order.Transactions.FirstOrDefault(h => h is { Kind: "SALE", Status: "PENDING" });
-        if (saleTx is null)
-            return logs;
-        //technically, this exploit should not be possible as we use internal invoice tags to verify that the invoice was created by our controlled, dedicated endpoint.
-        if (!invoice.Currency.Equals(saleTx.AmountSet.PresentmentMoney.CurrencyCode, StringComparison.OrdinalIgnoreCase))
-        {
-            // because of parent_id present, currency will always be the one from parent transaction
-            // malicious attacker could potentially exploit this by creating invoice 
-            // in different currency and paying that one, registering order on Shopify as paid
-            // so if currency is supplied and is different from parent transaction currency we just won't register
-            logs.Write("Currency mismatch on Shopify.", InvoiceEventData.EventSeverity.Error);
-            return logs;
-        }
+		var saleTx = order.Transactions
+			.Where(h => h is { Kind: "SALE", Status: "PENDING" })
+			.Where(h => h.AmountSet.PresentmentMoney.CurrencyCode.Equals(invoice.Currency, StringComparison.OrdinalIgnoreCase))
+			.FirstOrDefault();
+		if (saleTx is null)
+			return logs;
 
-        //of the successful ones, get the ones we registered as a valid payment
-        var captures = 
-            order.Transactions
-            .Where(h => h is { Kind: "SALE", Status: "SUCCESS" }).ToArray();
-        
-        
-        //of the successful ones, get the ones we registered as a voiding of a previous successful payment
-        var refunds = 
-            order.Transactions
-                .Where(h => h is { Kind: "REFUND", Status: "SUCCESS" }).ToArray();
+		var shopifyPaid =
+			order.Transactions
+			.Where(h => h is { Kind: "SALE", Status: "SUCCESS" })
+			.Select(h => h.AmountSet.PresentmentMoney.Amount)
+			.Sum();
 
-        bool canRefund = captures.Length > 0 && captures.Length > refunds.Length;
-        if (invoice is { Status: InvoiceStatus.Settled } or { Status:  InvoiceStatus.Expired, ExceptionStatus: InvoiceExceptionStatus.PaidPartial })
-        {
-            if (canRefund)
-            {
-                if (order.CancelledAt is not null)
-                {
-                    logs.Write("The shopify order has already been cancelled, but the BTCPay Server has been successfully paid.",
-                        InvoiceEventData.EventSeverity.Warning);
-                }
-                else
-                {
-                    logs.Write("A transaction was previously recorded against the Shopify order. Skipping.",
-                        InvoiceEventData.EventSeverity.Warning);
-                }
-                return logs;
-            }
+		decimal? btcpayPaid = invoice switch
+		{
+			{ Status: InvoiceStatus.Settled } => invoice.Price,
+			{ Status: InvoiceStatus.Expired, ExceptionStatus: InvoiceExceptionStatus.PaidPartial } => NetSettled(invoice),
+			{ Status: InvoiceStatus.Invalid, ExceptionStatus: InvoiceExceptionStatus.Marked } => 0.0m,
+			{ Status: InvoiceStatus.Invalid } => NetSettled(invoice),
+			_ => null
+		};
+		if (btcpayPaid is not null)
+		{
+			var capture = btcpayPaid.Value - shopifyPaid;
+			if (capture > 0m)
+			{
+				if (order.CancelledAt is not null)
+				{
+					logs.Write("The shopify order has already been cancelled, but the BTCPay Server has been successfully paid.",
+						InvoiceEventData.EventSeverity.Warning);
+					return logs;
+				}
 
-            if (saleTx.ManuallyCapturable)
-            {
-                try
-                {
-                    decimal amount = invoice.Status == InvoiceStatus.Settled ? invoice.Price 
-                        : Math.Round(invoice.PaidAmount.Net, _currencyNameTable.GetNumberFormatInfo(invoice.Currency)?.CurrencyDecimalDigits ?? 2);
+				if (saleTx.ManuallyCapturable)
+				{
+					try
+					{
+						await client.CaptureOrder(new()
+						{
+							Currency = invoice.Currency,
+							Amount = capture,
+							Id = order.Id,
+							ParentTransactionId = saleTx.Id
+						});
+						logs.Write(
+							$"Successfully captured the order on Shopify. ({capture} {invoice.Currency})",
+							InvoiceEventData.EventSeverity.Info);
+					}
+					catch (Exception e)
+					{
+						logs.Write($"Failed to capture the Shopify order. ({capture} {invoice.Currency}) {e.Message} ",
+							InvoiceEventData.EventSeverity.Error);
+					}
+				}
+			}
+		}
+		else if (order.CancelledAt is null)
+		{
+			try
+			{
+				await client.CancelOrder(new()
+				{
+					OrderId = order.Id,
+					NotifyCustomer = false,
+					Reason = OrderCancelReason.DECLINED,
+					Restock = true,
+					Refund = false,
+					StaffNote = $"BTCPay Invoice {invoice.Id} is {invoice.Status}"
+				});
+				logs.Write($"Shopify order cancelled. (Invoice Status: {invoice.Status})", InvoiceEventData.EventSeverity.Warning);
+			}
+			catch (Exception e)
+			{
+				logs.Write($"Failed to cancel the Shopify order. {e.Message}",
+					InvoiceEventData.EventSeverity.Error);
+			}
+		}
+		return logs;
+	}
 
-                    await client.CaptureOrder(new()
-                    {
-                        Currency = invoice.Currency,
-                        Amount = amount,
-                        Id = order.Id,
-                        ParentTransactionId = saleTx.Id
-                    });
-                    logs.Write(
-                        $"Successfully captured the order on Shopify.",
-                        InvoiceEventData.EventSeverity.Info);
-                }
-                catch (Exception e)
-                {
-                    logs.Write($"Failed to capture the Shopify order. {e.Message}",
-                        InvoiceEventData.EventSeverity.Error);
-                }
-            }
-        }
-        else if(order.CancelledAt is null)
-        {
-            try
-            {
-                await client.CancelOrder(new()
-                {
-                    OrderId = order.Id,
-                    NotifyCustomer = false,
-                    Reason = OrderCancelReason.DECLINED,
-                    Restock = true,
-                    Refund = canRefund,
-                    StaffNote = $"BTCPay Invoice {invoice.Id} is {invoice.Status}"
-                });
-                logs.Write($"Shopify order cancelled. (Invoice Status: {invoice.Status})", InvoiceEventData.EventSeverity.Warning);
-            }
-            catch (Exception e)
-            {
-                logs.Write($"Failed to cancel the Shopify order. {e.Message}",
-                    InvoiceEventData.EventSeverity.Error);
-            }
-        }
-        return logs;
-    }
+	private decimal NetSettled(InvoiceEntity invoice)
+	// The rounding is necessary, because shopify will interprete numbers wrong if the amount is not rounded
+	=> Math.Round(invoice.NetSettled, _currencyNameTable.GetNumberFormatInfo(invoice.Currency)?.CurrencyDecimalDigits ?? 2);
 }

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
@@ -168,6 +168,12 @@ public class ShopifyHostedService : EventHostedServiceBase
 	}
 
 	private decimal NetSettled(InvoiceEntity invoice)
-	// The rounding is necessary, because shopify will interprete numbers wrong if the amount is not rounded
-	=> Math.Round(invoice.NetSettled, _currencyNameTable.GetNumberFormatInfo(invoice.Currency)?.CurrencyDecimalDigits ?? 2);
+	{
+		decimal netSettled = netSettled = invoice.GetPayments(true)
+						.Where(payment => payment.Status == PaymentStatus.Settled)
+						.Sum(payment => payment.InvoicePaidAmount.Net);
+		// Later we can just use this instead of calculating ourselves
+		// decimal netSettled = invoice.NetSettled;
+		return Math.Round(netSettled, _currencyNameTable.GetNumberFormatInfo(invoice.Currency)?.CurrencyDecimalDigits ?? 2);
+	}
 }


### PR DESCRIPTION
## Summary

After talking with @pavlenex, @ndeet, and @TChukwuleta, I've decided to change how we handle invoice state transitions for Shopify.

We will need to update the documentation accordingly.

Before:

1. If an invoice was Invalid (fully paid but failed to confirm on time), the Shopify order was cancelled.
2. If an invoice was Partially Paid and failed to confirm on time, the Shopify order was marked as partially paid for the amount received (even if the payment wasn’t confirmed).
3. If, after a partial payment, the user manually marked the BTCPay invoice as Settled, it would trigger an error from Shopify.
4. If an invoice expired without payment, the order was cancelled and restocked.

After:

1. If an invoice is Partially Paid or Invalid (and not manually marked), the sum of confirmed payments up to the expiration is reflected in the Shopify order.
2. If an invoice is manually marked as Invalid in BTCPay Server, we do nothing.
3. As before, if an invoice expires without payment, the order is cancelled and restocked.
4. Manually setting an invoice as Settled after a partial payment will mark the Shopify order as fully paid.

## Typical flow for a user paying via BTCPay Server on Shopify

1. On the Thank you page of the shopify order, the users click on the payment button to open the BTCPay Server invoice.
2. The users pays with Bitcoin (on-chain).
3. When the transaction confirms, the BTCpay Server becomes `Settled`, and the Shopify Order becomes `Paid`.

## What happens if the customer didn't pay?

When the BTCPay invoice expires, the Shopify order becomes `Voided` and the stock is returned.

## What happens if the customer did pay, but without enough fee to confirm in a reasonable time?

The BTCPay invoice enters the `Invalid` state. The Shopify order remains `Payment Pending`.

## What happens if the customer paid partially?

The BTCPay invoice becomes `Expired`. The Shopify order either remains `Payment Pending` or is marked as `Partially Paid` for the amount that was confirmed at expiration.

## How to avoid partial payments?

Partial payments mainly occur when a customer pays from an exchange. The exchange subtracts fees from the sent amount, resulting in an underpayment. You can tolerate a small [underpayment percentage in your store's settings](https://docs.btcpayserver.org/FAQ/Stores/#consider-the-invoice-paid-even-if-the-paid-amount-is-less-than-expected) to avoid this.

## How to fix an underpayment or an Invalid invoice situation

Contact the customer and decide how to proceed. You can either:
* Mark the BTCPay invoice as Settled (this will also mark the Shopify order as paid)
* Mark the order as paid in Shopify