### PR TITLE
Configuration to handle restock when Invoice expires

### DIFF
--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/ShopifyStoreSettings.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/ShopifyStoreSettings.cs
@@ -11,7 +11,8 @@ namespace BTCPayServer.Plugins.ShopifyPlugin
 	    }
 		public const string SettingsName = "ShopifyPluginSettings";
 		public const string DefaultAppName = "BTCPay Server";
-	}
+        public bool RestockOnInvoiceExpired { get; set; } = true;
+    }
 
     public class ShopifySetupSettings
     {

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/ViewModels/ShopifySettingsViewModel.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/ViewModels/ShopifySettingsViewModel.cs
@@ -26,5 +26,6 @@ namespace BTCPayServer.Plugins.ShopifyPlugin.ViewModels
 		public string CLIToken { get; set; }
 		public string ShopUrl { get; set; }
 		public string ShopName { get; set; }
+        public bool RestockOnInvoiceExpired { get; set; }
     }
 }

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Views/UIShopify/Configuration.cshtml
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Views/UIShopify/Configuration.cshtml
@@ -1,0 +1,27 @@
+@using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Plugins.ShopifyPlugin.ViewModels
+@using Microsoft.AspNetCore.Routing
+@using BTCPayServer.Plugins.ShopifyPlugin.Blazor
+@model ShopifySettingsViewModel
+@{
+    ViewData.SetActivePage("Shopify", "Shopify  App Configuration", "Shopify");
+}
+
+<form method="post" asp-action="Configuration" asp-controller="UIShopifyV2">
+    <div class="sticky-header d-flex align-items-center justify-content-between">
+        <h2>@ViewData["Title"]</h2>
+        <button type="submit" class="btn btn-primary" id="Edit" value="Save Changes">Save Changes</button>
+    </div>
+
+    <partial name="_StatusMessage" />
+
+    <div class="row">
+        <div class="col-xl-10 col-xxl-constrain">
+            <div class="form-group d-flex align-items-center">
+                <input asp-for="RestockOnInvoiceExpired" type="checkbox" class="btcpay-toggle me-3" />
+                <label asp-for="RestockOnInvoiceExpired" class="form-label mb-0 me-1">Restock product items when invoice expires</label>
+                <span asp-validation-for="RestockOnInvoiceExpired" class="text-danger"></span>
+            </div>
+        </div>
+    </div>
+</form>

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Views/UIShopify/Settings.cshtml
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Views/UIShopify/Settings.cshtml
@@ -32,6 +32,10 @@
             </small>
         </h2>
         <div>
+            @if (Model.Step == ShopifySettingsViewModel.State.Done)
+            {
+                <a asp-controller="UIShopifyV2" asp-action="Configuration" asp-route-storeId="@storeId" class="btn btn-primary">Configuration</a>
+            }
             @if (Model.Step != ShopifySettingsViewModel.State.WaitingClientCreds)
             {
                 <form method="post">

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   shopify-app-deployer:
-    image: btcpayserver/shopify-app-deployer:1.4
+    image: btcpayserver/shopify-app-deployer:1.5
     restart: unless-stopped
     init: true
     expose:


### PR DESCRIPTION
Resolves #6 

Right now the plugin restock items when an invoice expires without payment

However according to @nitramiz that is messing up accounting calculations.

So I made the restock to be a configuration defaulted at true in a view
