### PR TITLE
ensure required scopes are available for refunds

### DIFF
--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/BTCPayServer.Plugins.ShopifyPlugin.csproj
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/BTCPayServer.Plugins.ShopifyPlugin.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <Product>BTCPay Server Shopify Plugin v2</Product>
     <Description>BTCPay server integration with Shopify.</Description>
-    <Version>1.0.9</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <!-- Plugin development properties -->

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/Services/ShopifyHostedService.cs
@@ -1,4 +1,9 @@
-﻿using BTCPayServer.Client.Models;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
 using BTCPayServer.Events;
 using BTCPayServer.HostedServices;
@@ -8,10 +13,6 @@ using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Rates;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace BTCPayServer.Plugins.ShopifyPlugin.Services;
 
@@ -71,8 +72,13 @@ public class ShopifyHostedService : EventHostedServiceBase
         }
     }
 
-    private static string[] _keywords = new[] { "bitcoin", "btc", "btcpayserver", "btcpay server" };
+    private static string[] _requiredAppScopes = new[] { "read_orders", "write_orders", "read_customers" };
+    public static bool HasRequiredShopifyScopes(IEnumerable<string> grantedScopes)
+    {
+        return _requiredAppScopes.All(required => grantedScopes.Contains(required, StringComparer.OrdinalIgnoreCase));
+    }
 
+    private static string[] _keywords = new[] { "bitcoin", "btc", "btcpayserver", "btcpay server" };
     public static bool IsBTCPayServerGateway(string gateway)
     {
         return _keywords.Any(keyword => gateway.Contains(keyword, StringComparison.OrdinalIgnoreCase));

--- a/Plugins/BTCPayServer.Plugins.ShopifyPlugin/ViewModels/ShopifyRefundWebhook.cs
+++ b/Plugins/BTCPayServer.Plugins.ShopifyPlugin/ViewModels/ShopifyRefundWebhook.cs
@@ -29,3 +29,9 @@ public class ShopifyOrderAdjustment
     [JsonProperty("amount")]
     public decimal Amount { get; set; }
 }
+
+public class AccessScopeHandle
+{
+    [JsonProperty("handle")]
+    public string Handle { get; set; }
+}


### PR DESCRIPTION
This PR alerts the users to upgrade their shopify fragment to the latest and also redeploy their app in order to be able to have access to refunds functionality


<img width="1613" height="634" alt="image" src="https://github.com/user-attachments/assets/76712e5f-f6e9-455d-8e6f-226b455b138e" />
